### PR TITLE
Bump atlantis and terragrunt versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM runatlantis/atlantis:v0.9.0
+FROM runatlantis/atlantis:v0.10.2
 
-ARG TERRAGRUNT_VERSION=v0.19.26
+ARG TERRAGRUNT_VERSION=v0.21.11
 ENV TERRAGRUNT_VERSION=$TERRAGRUNT_VERSION
 
 # Download Terragrunt


### PR DESCRIPTION
Bump atlantis and terragrunt versions

atlantis - v0.9.0 -> v0.10.2
terragrunt v0.19.26 -> v0.21.11